### PR TITLE
Reuse login session, improve error messages

### DIFF
--- a/app/err/exceptions.py
+++ b/app/err/exceptions.py
@@ -5,17 +5,10 @@ class NoAuthTokenError(Exception):
     """Exception for missing/required auth."""
 
     def __init__(self, message, status_code=None, payload=None):
-        super().__init__(self)
-        self.message = message
-        self.status_code = status_code
-        self.payload = payload
-
+        super().__init__(message, status_code, payload)
 
 class ModemNotOkError(Exception):
     """Exception for non-200/OK responses from modem."""
 
     def __init__(self, message, status_code=None, payload=None):
-        super().__init__(self)
-        self.message = message
-        self.status_code = status_code
-        self.payload = payload
+        super().__init__(message, status_code, payload)

--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,7 @@ import asyncio
 from os import getenv
 
 import structlog
-from aiohttp import BasicAuth, ClientSession
+from aiohttp import BasicAuth, ClientSession, CookieJar
 from err.exceptions import ModemNotOkError, NoAuthTokenError
 from prometheus_client import start_http_server
 from sb8200.parse import (
@@ -71,6 +71,8 @@ async def main():
         auth=BasicAuth(MODEM_USERNAME, MODEM_PASSWORD),
         base_url=MODEM_BASE_URL,
         headers=REQUEST_HEADERS,
+        # unsafe=True: tell aiohttp to allow cookies on IP addresses
+        cookie_jar=CookieJar(unsafe=True)
     )
 
     csrf_token = None

--- a/app/main.py
+++ b/app/main.py
@@ -102,6 +102,7 @@ async def main():
             _e = "Unforeseen exception. Treating as non-fatal."
             log.error(_e, error=e)
             continue
+    await client.close()
 
 
 if __name__ == "__main__":

--- a/app/sb8200/parse.py
+++ b/app/sb8200/parse.py
@@ -12,6 +12,9 @@ from bs4 import BeautifulSoup
 
 log = structlog.get_logger(__name__)
 
+def is_login_page(soup: BeautifulSoup) -> bool:
+    """Check if the page is the login page"""
+    return soup.find("title").text.strip() == "Login"
 
 def get_modem_info(soup: BeautifulSoup) -> dict[str, None | str | timedelta]:
     """Attempts to extract some modem information from the product-info page.

--- a/app/sb8200/scrape.py
+++ b/app/sb8200/scrape.py
@@ -75,7 +75,8 @@ async def do_modem_scrape(
                     _e = f"Modem indicated authentication details are incorrect. Check for extra/incorrect quotes in your env-vars? Status={resp.status}."
                 else:
                     _e = f"Failed to log in. Status={resp.status}."
-                raise ModemNotOkError(_e)
+                payload = await resp.text()
+                raise ModemNotOkError(_e, status_code=resp.status, payload=payload)
 
             csrf_token = await resp.text()
             log.debug("CSRF Token", token=csrf_token)
@@ -102,7 +103,8 @@ async def do_modem_scrape(
             metrics.c_meta_scrape_result.labels(resp.status, "connection_data").inc()
             if resp.status != 200:
                 _e = f"Failed to get connection status. Status={resp.status}"
-                raise ModemNotOkError(_e)
+                payload = await resp.text()
+                raise ModemNotOkError(_e, status_code=resp.status, payload=payload)
             raw_connection_state = await resp.text()
 
     # Quickly try to get the product info
@@ -119,7 +121,8 @@ async def do_modem_scrape(
             metrics.c_meta_scrape_result.labels(resp.status, "product_info").inc()
             if resp.status != 200:
                 _e = f"Failed to get product info. Status={resp.status}"
-                raise ModemNotOkError(_e)
+                payload = await resp.text()
+                raise ModemNotOkError(_e, status_code=resp.status, payload=payload)
             raw_product_info = await resp.text()
 
     # Assuming nothing went wrong, we can now parse the HTML

--- a/app/sb8200/scrape.py
+++ b/app/sb8200/scrape.py
@@ -67,14 +67,6 @@ async def do_login(cs: ClientSession) -> str:
 
             csrf_token = await resp.text()
             log.debug("CSRF Token", token=csrf_token)
-
-            # We need to parse the cookies and update the client's cookie jar
-            set_cookie_header = resp.headers.get("Set-Cookie")
-            if set_cookie_header:
-                cookie = http.cookies.SimpleCookie()
-                cookie.load(set_cookie_header)
-                cs.cookie_jar.update_cookies(cookie)
-
             log.debug("Cookie jar", count=len(cs.cookie_jar))
     log.info("Done with login.")
     return csrf_token


### PR DESCRIPTION
Reuse the login session from one scrape to the next to avoid the unreliable login step.

Detect an unsuccessful scrape of statistics that returns the Login page, and try logging in again. If it was immediately after logging in, then wait 5s before logging in again.

Improve error messages:
* Fix `Exception` super calls that resulted in `RecursionError` when `repr`ing the exceptions
* When the Login page is detected, log “Login succeeded but stats page still returned Login page” instead of “Failed to parse modem datetime. HTML scrape error?” and “Failed to parse product_info/uptime as timedelta. Scrape issue?”.